### PR TITLE
[feat,fix]build.xml,Makefile,clang-format-for-java.yml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,6 @@ wipe: clean
 zip:
 	$(ANT) zip
 
-# zip: wipe
-# 	@find . -exec touch -t `date "+%Y%m%d%H%M"` {} \; ; xattr -cr .
-# 	(cd ../ ; zip -r ./$(ARCHIVE).zip ./$(ARCHIVE)/ --exclude='*/.svn/*')
-
 format:
 	@rm -f $(STYLE_CONF) ; ln -s $(STYLE_YAML) $(STYLE_CONF)
 	for each in $(SOURCES) ; do echo ---[$${each}]--- ; clang-format -style=file $${each} ; echo ; done

--- a/build.xml
+++ b/build.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<project name="MVC" default="all" basedir=".">
+<project name="Wavelet" default="all" basedir=".">
 
+	<property name="mvc" value="mvc" /> 
 	<property name="package" value="wavelet" />
-	<property name="condition" value="condition" />
-	<property name="packagenames" value="${package},${condition}" />
+	<property name="utility" value="utility" />
+	<property name="pane" value="pane" />
+	<property name="packagenames" value="${package},${mvc},${utility},${pane}" />
+
 	<property name="destdir" value="./Classes" />
 	<property name="docdir" value="./JavaDoc" />
 	<property name="instdir" value="./${ant.project.name}.app/Contents/Resources/Java" />
@@ -33,7 +36,6 @@
 			<compilerarg value="-Xlint:all" />
 			<classpath>
 				<pathelement location="." />
-				<pathelement location="${condition}.jar" />
 			</classpath>
 		</javac>
 		<exec executable="date" spawn="false" />
@@ -43,7 +45,7 @@
 		<jar
 			destfile="${destdir}/${package}.jar"
 			basedir="${destdir}"
-			includes="*.class"
+			includes="**/*.class"
 		>
 			<manifest>
 				<attribute name="Project" value="XX"  />
@@ -61,13 +63,9 @@
 
 	<target name="clean" description="cleaning">
 		<delete dir="${destdir}" />
-		<delete file="${package}.jar" />
 		<delete dir="${docdir}" />
 		<delete dir="${instdir}" />
 		<delete file="../${zipname}.zip" />
-		<delete>
-			<fileset dir="${package}" includes="*.class" />
-		</delete>
 		<exec executable="date" spawn="false" />
 	</target>
 
@@ -105,7 +103,6 @@
 			<bottom>${copyright}</bottom>
 			<classpath>
 				<pathelement location="." />
-				<pathelement location="${condition}.jar" />
 			</classpath>
 		</javadoc>
 		<exec executable="open">

--- a/clang-format-for-java.yaml
+++ b/clang-format-for-java.yaml
@@ -1,0 +1,96 @@
+---
+Language:        Java
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: false
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: false
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:   
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Allman
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     0
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 8
+ContinuationIndentWidth: 8
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeCategories: 
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+  - Regex:           '^(<|"(gtest|isl|json)/)'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IncludeIsMainRegex: '$'
+IndentCaseLabels: false
+IndentWidth:     8
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Auto
+TabWidth:        8
+UseTab:          ForIndentation
+...
+


### PR DESCRIPTION
antを使ったmakeコマンドを処理を修正
・build.xmlのプロジェクト名をアプリ名と一致させるようにした
・使用しないプロパティ(condition)を消去、今後作成予定のpackageを追加、適用されるように変更 ・jarタスクのincludesをClassesのすべてのパッケージを含めるように変更